### PR TITLE
style: #132 table expand icon color

### DIFF
--- a/theme/dt-theme/dt-common/table.less
+++ b/theme/dt-theme/dt-common/table.less
@@ -87,6 +87,9 @@
     &::after {
         color: @bule;
     }
+    &:hover, &:focus, &:active {
+        border-color: @bule;
+    }
 }
 
 .ant-table-tbody > tr > td.ant-table-selection-column {


### PR DESCRIPTION
#132  table 展开折叠的 icon 颜色  

![image](https://user-images.githubusercontent.com/34759874/196077368-ad49135b-df02-4b99-ba47-a3e7b13b7903.png)
