### PR TITLE
Beta 2.0.0 271 265

### DIFF
--- a/theme/dt-theme/default/collapse.less
+++ b/theme/dt-theme/default/collapse.less
@@ -37,7 +37,7 @@
                     padding: 10px 16px 10px 0;
                     margin: 0;
                 }
-                .ant-collapse {
+                & > .ant-collapse {
                     margin-left: 24px;
                     border: none;
                     border-left: 1px solid @black_readonly;

--- a/theme/dt-theme/default/drawer.less
+++ b/theme/dt-theme/default/drawer.less
@@ -11,7 +11,7 @@
 .ant-drawer-header {
     padding: 16px;
     background-color: @black_navBg;
-    border-bottom: 1px solid @grey_border;
+    border-bottom: 0;
     .ant-drawer-header-title {
         flex-direction: row-reverse;
         .ant-drawer-close {


### PR DESCRIPTION
Modify:
1、去除抽屉header底线

2、根据UI5.0优化折叠面板样式，当两个面板直接嵌套式为
![image](https://user-images.githubusercontent.com/55699373/199390790-4156879a-9a0c-4d3f-87fb-c8d4b8ab2b2a.png)
未直接嵌套第二个面板样式不做修改

Relation:
#271 #265 