### PR TITLE
style: optimized modal confirm text align #340

### DIFF
--- a/theme/dt-theme/default/modal.less
+++ b/theme/dt-theme/default/modal.less
@@ -60,7 +60,7 @@
                 }
                 .anticon {
                     margin: 0 8px 0 2px;
-                    line-height: 22px;
+                    line-height: 20px;
                     font-size: 16px;
                     svg {
                         vertical-align: inherit;
@@ -69,6 +69,7 @@
                 .ant-modal-confirm-content {
                     margin: 8px 0 16px 27px;
                     color: @black_pageMsg;
+                    line-height: 20px;
                 }
             }
             .ant-modal-confirm-btns {


### PR DESCRIPTION
Modify:
1、跳转confirm中图标和内容的line-height

Relation:
#340 