### PR TITLE
feat: optimized dt-table-empty-top-20-percent empty hover style #469

### DIFF
--- a/theme/dt-theme/default/table.less
+++ b/theme/dt-theme/default/table.less
@@ -575,6 +575,9 @@
                                         transform: translate(-50%, 0);
                                     }
                                 }
+                                &:hover > td {
+                                    background-color: inherit;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Modify:
- 定位到由该样式引起，修改为`inherit`，已经在资产中验证 #469 
![image](https://user-images.githubusercontent.com/55699373/207561885-411a87e3-6ccb-4713-9b1a-435bf091be59.png)
