### PR TITLE
fix: #530 .ant-modal-confirm-body > .anticon

### DIFF
--- a/components/modal/demo/containForm.md
+++ b/components/modal/demo/containForm.md
@@ -10,6 +10,7 @@ title:
 
 ```jsx
 import { Modal, Button, Form, Input, Select } from 'antd';
+import { CloseCircleFilled } from '@ant-design/icons';
 
 class App extends React.Component {
   state = { visible: false };
@@ -17,6 +18,35 @@ class App extends React.Component {
   showModal = () => {
     this.setState({
       visible: true,
+    });
+  };
+
+  showModalConfirm = () => {
+    console.log(111)
+    const options = [
+      { label: '规则1', value: 1 },
+      { label: '规则2', value: 2 },
+    ]
+    Modal.confirm({
+      title: '确认删除吗？',
+      icon: <CloseCircleFilled style={{ color: '#f96c5b' }} />,
+      content: (
+        <div>
+          <p>删除当前规则后不再校验离线的任务SQL，无法约束代码SQL的规范性。</p>
+          <p style={{ color: '#F96C5B', marginBottom: 16 }}>删除后规则信息将无法恢复，请谨慎操作！</p>
+          <Form layout="vertical" preserve={false}>
+            <Form.Item
+              label="检查规则名称"
+              name="ruleName"
+            >
+              <Select placeholder="请选择检查规则名称" options={options} />
+            </Form.Item>
+          </Form>
+        </div>
+      ),
+      okType: 'danger',
+      okText: '确认',
+      cancelText: '取消',
     });
   };
 
@@ -37,9 +67,14 @@ class App extends React.Component {
   render() {
     return (
       <div>
-        <Button type="primary" onClick={this.showModal}>
-          Open Modal
-        </Button>
+        <div className="demo-modal-box">
+          <Button type="primary" onClick={this.showModal}>
+            Open Modal
+          </Button>
+          <Button type="primary" onClick={this.showModalConfirm}>
+            Contain Form By Modal.confirm
+          </Button>
+        </div>
         <Modal
           width={640}
           title="Basic Modal"

--- a/theme/dt-theme/default/modal.less
+++ b/theme/dt-theme/default/modal.less
@@ -62,7 +62,7 @@
                     line-height: 20px;
                     font-size: 14px;
                 }
-                .anticon {
+                > .anticon {
                     margin: 0 8px 0 2px;
                     font-size: 20px;
                     svg {


### PR DESCRIPTION
1. #530   

前后对比：
![image](https://github.com/DTStack/ant-design-dtinsight-theme/assets/34759874/968e4846-06d2-4647-9214-cbfcb63967eb)
<img width="678" alt="image" src="https://github.com/DTStack/ant-design-dtinsight-theme/assets/34759874/1f75868d-a504-4439-be20-f5637df8c94e">

在文档中添加了一个示例：
<img width="1448" alt="image" src="https://github.com/DTStack/ant-design-dtinsight-theme/assets/34759874/947ec9c9-d577-49be-a0f1-fb1d9ee3034f">
