### PR TITLE
fix: #554 time date picker icon size

### DIFF
--- a/theme/dt-theme/default/datepicker.less
+++ b/theme/dt-theme/default/datepicker.less
@@ -173,3 +173,17 @@
         }
     }
 }
+
+// TimePicker
+.ant-picker-suffix {
+    .anticon-clock-circle, .anticon-calendar {
+        font-size: 16px;
+    }
+}
+
+.ant-picker-clear {
+    // 需要设置同样大小，如果 clear 图标小一点的话，会无法覆盖下方的时钟、日期图标，导致 hover 时显示错位
+    .anticon-close-circle {
+        font-size: 16px;
+    }
+}


### PR DESCRIPTION
1. #554 

<img width="1550" alt="image" src="https://github.com/DTStack/ant-design-dtinsight-theme/assets/34759874/96e9f0fa-4f45-4941-815c-256758a027b0">
<img width="670" alt="image" src="https://github.com/DTStack/ant-design-dtinsight-theme/assets/34759874/55f8f43c-7d35-4a3d-ad85-b1a57dc1ca05">
