### PR TITLE
fix: #576 remove ant-input-affix-wrapper padding

### DIFF
--- a/theme/dt-theme/default/input.less
+++ b/theme/dt-theme/default/input.less
@@ -2,8 +2,6 @@
 
 .ant-input,
 .ant-input-affix-wrapper {
-    padding: 5px 11px;
-    line-height: 20px;
     .ant-input-suffix {
         .anticon-info-circle {
             font-size: 13px;


### PR DESCRIPTION
1. #576 

原因：theme 仅写了 ant-input-affix-wrapper 的 padding，这样会覆盖 antd 的，且会覆盖 &-sm、&-lg 的样式


![2024-09-10 11 56 43](https://github.com/user-attachments/assets/f3d0d558-6182-4dc8-a5dc-030ae630b29b)
