### PR TITLE
fix(table): #595, rewrite ant-table-placeholder when in ant-table-expanded-row

### DIFF
--- a/theme/dt-theme/default/table.less
+++ b/theme/dt-theme/default/table.less
@@ -221,14 +221,6 @@
                             flex-direction: column;
                             .ant-table-body {
                                 flex: 1;
-
-                                /** 内部嵌套表格，数据为空的情况 */
-                                .ant-table-expanded-row .ant-table-empty {
-                                    .ant-table-placeholder {
-                                        position: relative;
-                                        top: unset;
-                                    }
-                                }
                             }
                         }
                         .ant-table-fixed-left, .ant-table-fixed-right {
@@ -244,6 +236,13 @@
                             width: 100%;
                             text-align: center;
                             border: none;
+                        }
+                    }
+                    /** 内部嵌套表格，数据为空的情况 */
+                    .ant-table-expanded-row .ant-table-empty {
+                        .ant-table-placeholder {
+                            position: relative;
+                            top: unset;
                         }
                     }
                 }
@@ -294,14 +293,6 @@
                             height: 100%;
                             .ant-table-body {
                                 height: calc(100% - 44px); // 表格 header 高度为 44px
-
-                                /** 内部嵌套表格，数据为空的情况 */
-                                .ant-table-expanded-row .ant-table-empty {
-                                    .ant-table-placeholder {
-                                        position: relative;
-                                        top: unset;
-                                    }
-                                }
                             }
                         }
                         .ant-table-fixed-right, .ant-table-fixed-left {
@@ -324,6 +315,13 @@
                             color: #BFBFBF;
                             text-align: center;
                             border: none;
+                        }
+                    }
+                    /** 内部嵌套表格，数据为空的情况 */
+                    .ant-table-expanded-row .ant-table-empty {
+                        .ant-table-placeholder {
+                            position: relative;
+                            top: unset;
                         }
                     }
                 }


### PR DESCRIPTION
导致原因为：ant-table-placeholder 为 absulte 了，ant-table-body 高度无法撑高
<img width="281" height="197" alt="image" src="https://github.com/user-attachments/assets/cb67c36c-7b9a-45d5-845a-564ce873496c" />

以前写的内容，应该是在 ant-table-expanded-row 下面重写了 ant-table-placeholder，但是层级问题尚未生效
<img width="534" height="172" alt="image" src="https://github.com/user-attachments/assets/2abf12b3-98e3-4934-beb4-4cce40fe9867" />
上述图片的内容 .ant-table-expanded-row 写在 .ant-table-content 内部，但是 .ant-table-expanded-row 是 .ant-table-content 父级，因为更改位置即可
